### PR TITLE
Grab rollModes from their new CONFIG Location

### DIFF
--- a/src/requestor.js
+++ b/src/requestor.js
@@ -28,7 +28,7 @@ class LMRTFYRequestor extends FormApplication {
             users,
             abilities,
             skills,
-            rollModes: CONFIG.rollModes
+            rollModes: CONFIG.Dice.rollModes
         };
     }
 


### PR DESCRIPTION
CONFIG.rollModes is no longer the location to access roll modes. It's in CONFIG.Dice.rollModes now so the roll modes dropdown didn't populate.